### PR TITLE
Allow to encode in base64 the Secure Bundle ZIP

### DIFF
--- a/common/src/main/java/com/datastax/oss/common/sink/config/CassandraSinkConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/CassandraSinkConfig.java
@@ -353,7 +353,6 @@ public class CassandraSinkConfig {
   }
 
   static void decodeBase64EncodedSecureBundle(Map<String, String> javaDriverSettings) {
-    // it is very awkward on k8s to pass ZIP files
     // if the path is base64:xxxx we decode the payload and create
     // a temporary file
     // we are setting permissions such that only current user can access the file
@@ -447,7 +446,6 @@ public class CassandraSinkConfig {
     // handle usage of deprecated setting
     if (connectorSettings.containsKey(connectorDeprecatedSetting)) {
       // put or override if setting with datastax-java-driver prefix provided
-      log.info("handling deprecated {}, set as {}", connectorDeprecatedSetting, driverSetting);
       javaDriverSettings.put(
           driverSetting,
           deprecatedValueConverter.apply(connectorSettings.get(connectorDeprecatedSetting)));


### PR DESCRIPTION
Allow to configure SecureBundle ZIP in textual form
    - allow users to encode the ZIP file using standard base64 linux tool
    - This is the new setting cloud.secureConnectBundle=base64:XXXXXXXXX
    
With this change it is easier to connect to Astra and to secure Cassandra clusters without the need to deploy the ZIP file.
Deploying the ZIP file is very awkward on K8S and in Pulsar IO framework