### PR TITLE
Reuse for source connector

### DIFF
--- a/common/src/main/java/com/datastax/oss/common/sink/config/AuthenticatorConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/AuthenticatorConfig.java
@@ -37,9 +37,9 @@ public class AuthenticatorConfig extends AbstractConfig {
   public static final String PROVIDER_OPT = "auth.provider";
   public static final String USERNAME_OPT = "auth.username";
   public static final String PASSWORD_OPT = "auth.password";
-  static final String KEYTAB_OPT = "auth.gssapi.keyTab";
-  static final String PRINCIPAL_OPT = "auth.gssapi.principal";
-  static final String SERVICE_OPT = "auth.gssapi.service";
+  public static final String KEYTAB_OPT = "auth.gssapi.keyTab";
+  public static final String PRINCIPAL_OPT = "auth.gssapi.principal";
+  public static final String SERVICE_OPT = "auth.gssapi.service";
 
   private static final Logger log = LoggerFactory.getLogger(AuthenticatorConfig.class);
   private static final ConfigDef CONFIG_DEF =
@@ -83,7 +83,7 @@ public class AuthenticatorConfig extends AbstractConfig {
 
   @Nullable private final Path keyTabPath;
 
-  AuthenticatorConfig(Map<String, String> authSettings) {
+  public AuthenticatorConfig(Map<String, String> authSettings) {
     super(CONFIG_DEF, sanitizeAuthSettings(authSettings), false);
 
     // Verify that the provider value is valid.

--- a/common/src/main/java/com/datastax/oss/common/sink/config/ConfigUtil.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/ConfigUtil.java
@@ -39,7 +39,7 @@ class ConfigUtil {
    * @param settingNames names of settings to extract.
    * @return lines of the form "setting: value".
    */
-  static String configToString(
+  public static String configToString(
       AbstractConfig config, String prefixToExcise, String... settingNames) {
     return Arrays.stream(settingNames)
         .map(
@@ -56,7 +56,7 @@ class ConfigUtil {
    * @param settingValue setting to convert
    * @return the converted path.
    */
-  static @Nullable Path getFilePath(@Nullable String settingValue) {
+  public static @Nullable Path getFilePath(@Nullable String settingValue) {
     return settingValue == null || settingValue.isEmpty()
         ? null
         : Paths.get(settingValue).toAbsolutePath().normalize();
@@ -69,7 +69,7 @@ class ConfigUtil {
    * @param settingName name of setting whose value is filePath; used in generating error messages
    *     for failures.
    */
-  static void assertAccessibleFile(@Nullable Path filePath, String settingName) {
+  public static void assertAccessibleFile(@Nullable Path filePath, String settingName) {
     if (filePath == null) {
       // There's no path to check.
       return;

--- a/common/src/main/java/com/datastax/oss/common/sink/config/ContactPointsValidator.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/ContactPointsValidator.java
@@ -45,7 +45,7 @@ public class ContactPointsValidator {
     }
   }
 
-  private static boolean isInvalidAddress(String contactPoint) {
+  public static boolean isInvalidAddress(String contactPoint) {
     return !InetAddresses.isInetAddress(contactPoint) && !InternetDomainName.isValid(contactPoint);
   }
 }

--- a/common/src/main/java/com/datastax/oss/common/sink/config/SslConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/SslConfig.java
@@ -113,7 +113,7 @@ public class SslConfig extends AbstractConfig {
   private final @Nullable Path privateKeyPath;
   private final @Nullable SslContext sslContext;
 
-  SslConfig(Map<String, String> sslSettings) {
+  public SslConfig(Map<String, String> sslSettings) {
     super(CONFIG_DEF, sslSettings, false);
 
     keystorePath = getFilePath(getString(KEYSTORE_PATH_OPT));

--- a/common/src/main/java/com/datastax/oss/common/sink/config/TableConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/TableConfig.java
@@ -66,7 +66,7 @@ public class TableConfig extends AbstractConfig {
   private final boolean deletesEnabled;
   private final String query;
 
-  private TableConfig(
+  public TableConfig(
       @NonNull String topicName,
       @NonNull String keyspace,
       @NonNull String table,


### PR DESCRIPTION
* Change some classes and members visibility from private to public in order to reuse it in the Cassandra source connector configuration.