### PR TITLE
Change visibility to public of static ConfigDef variables

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>messaging-connectors-commons-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>1.0.12-SNAPSHOT</version>
+    <version>1.0.13-SNAPSHOT</version>
   </parent>
   <artifactId>messaging-connectors-commons-core</artifactId>
   <name>DataStax Apache Cassandra (R) Messaging Sink Connectors - Common</name>

--- a/common/src/main/java/com/datastax/oss/common/sink/config/AuthenticatorConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/AuthenticatorConfig.java
@@ -42,7 +42,7 @@ public class AuthenticatorConfig extends AbstractConfig {
   public static final String SERVICE_OPT = "auth.gssapi.service";
 
   private static final Logger log = LoggerFactory.getLogger(AuthenticatorConfig.class);
-  private static final ConfigDef CONFIG_DEF =
+  public static final ConfigDef CONFIG_DEF =
       new ConfigDef()
           .define(
               PROVIDER_OPT,

--- a/common/src/main/java/com/datastax/oss/common/sink/config/SslConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/SslConfig.java
@@ -51,7 +51,7 @@ public class SslConfig extends AbstractConfig {
   public static final String TRUSTSTORE_PATH_OPT = "ssl.truststore.path";
   static final String CIPHER_SUITES_OPT = "ssl.cipherSuites";
 
-  private static final ConfigDef CONFIG_DEF =
+  public static final ConfigDef CONFIG_DEF =
       new ConfigDef()
           .define(
               PROVIDER_OPT,

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <groupId>com.datastax.oss</groupId>
   <artifactId>messaging-connectors-commons-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.12-SNAPSHOT</version>
+  <version>1.0.13-SNAPSHOT</version>
   <name>DataStax Apache Cassandra (R) Messaging Connectors</name>
   <description>Common utilities for pulling data from Messaging middlewares and inserting into Apache Cassandra (R) or DataStax Enterprise (DSE)</description>
   <url>https://github.com/riptano/messaging-connectors-commons</url>


### PR DESCRIPTION
Change the visibility of ConfigDef static variables in order to generate the ASCIIDOC documentation.