### PR TITLE
Fix: skip topic.creation.* properties injected by Confluent Cloud

### DIFF
--- a/common/src/main/java/com/datastax/oss/common/sink/config/CassandraSinkConfig.java
+++ b/common/src/main/java/com/datastax/oss/common/sink/config/CassandraSinkConfig.java
@@ -238,6 +238,10 @@ public class CassandraSinkConfig {
       for (Map.Entry<String, String> entry : settings.entrySet()) {
         String name = entry.getKey();
         if (name.startsWith("topic.")) {
+          // Skip Confluent Cloud injected topic creation properties
+          if (name.startsWith("topic.creation.")) {
+            continue;
+          }
           String topicName = tryMatchTopicName(name);
           Map<String, String> topicMap =
               topicSettings.computeIfAbsent(topicName, t -> new HashMap<>());


### PR DESCRIPTION
Confluent Cloud custom connector environment automatically injects topic.creation.default.partitions and topic.creation.default.replication.factor into connector configurations. CassandraSinkConfig.tryMatchTopicName() was rejecting these properties because they start with 'topic.' but do not match the expected topic.<topicname>.<keyspace>.<table> pattern.

Added a guard in the constructor to skip topic.creation.* properties before passing them to tryMatchTopicName(), allowing the connector to run in Confluent Cloud custom connector environments.

Fixes datastax/kafka-sink#160
Fixes datastax/messaging-connectors-commons#22
